### PR TITLE
Add link to home on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -22,4 +22,5 @@ layout: default
 
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url }}">Back to Home</a></p>
 </div>


### PR DESCRIPTION
## Summary
- add a link on the 404 page so visitors can return to the homepage

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684aed7e84108329a35988dca338df83